### PR TITLE
capture groups: Allowing to run a fn on a capture

### DIFF
--- a/stream-grep.js
+++ b/stream-grep.js
@@ -2,14 +2,18 @@ var split = require('split')
   , EventListener = require('events').EventEmitter
   , ReadableStream = require('stream').Readable
 
-function find(stream, terms) {
+function checkStream(stream) {
+  if (!(stream instanceof ReadableStream)) {
+    throw new Error('stream must be a readable stream')
+  }
+}
+
+function find(stream, terms, matcher) {
   var lineCount = 0
     , found = 0
     , el = new EventListener()
 
-  if (!(stream instanceof ReadableStream)) {
-    throw new Error('stream must be a readable stream')
-  }
+  checkStream(stream)
 
   if (!Array.isArray(terms)) {
     if (terms) {
@@ -23,10 +27,32 @@ function find(stream, terms) {
     throw new Error('\'terms\' must be not be empty')
   }
 
+  if (typeof matcher !== 'undefined') {
+    if (typeof matcher !== 'function') {
+      matcher = function () { return true }
+    }
+  }
+
   stream
   .pipe(split())
   .on('data', function (line) {
     lineCount += 1
+    if (matcher) {
+      terms.forEach(function (reg) {
+        var foundItems = reg.exec(line)
+        if (foundItems && foundItems.length > 0 && foundItems[0] !== '') {
+          foundItems.forEach(function (item, i) {
+            // Only show captured groups.
+            if (i === 0) return
+            if (matcher(item)) {
+              el.emit('captured', item, lineCount)
+              found += 1
+            }
+          })
+        }
+      })
+      return
+    }
     terms.forEach(function (reg) {
       if (line.match(reg)) {
         el.emit('found', reg, lineCount)

--- a/test/stream-grep.test.js
+++ b/test/stream-grep.test.js
@@ -35,9 +35,13 @@ describe('stream-grep', function () {
   })
 
   it('should find instance of regexp and return line', function (done) {
+    var found = []
     streamGrep(getStream(), /terms\.forEach/)
     .on('found', function(term, line) {
-      line.should.eql(30)
+      found.push(line)
+    })
+    .on('end', function() {
+      found.should.eql([41, 56])
       done()
     })
   })
@@ -45,7 +49,7 @@ describe('stream-grep', function () {
   it('should find instance of regexp and return count on end event', function (done) {
     streamGrep(getStream(), /terms\.forEach/)
     .on('end', function(found) {
-      found.should.eql(1)
+      found.should.eql(2)
       done()
     })
   })
@@ -57,7 +61,31 @@ describe('stream-grep', function () {
       found.push(line)
     })
     .on('end', function() {
-      found.should.eql([5, 14, 15, 16, 18, 22, 23, 27, 30])
+      found.should.eql([11, 18, 19, 20, 22, 26, 27, 37, 41, 56])
+      done()
+    })
+  })
+
+  it('should find instance of many regexps using capture', function (done) {
+    var found = []
+    streamGrep(getStream(), /\'((?:\\.|[^\'\\])*)\'/, function () { return true })
+    .on('captured', function(term, line) {
+      found.push(line)
+    })
+    .on('end', function() {
+      found.should.eql([1, 2, 3, 7, 27, 30, 31, 38, 43, 48, 58, 63, 64, 66, 67])
+      done()
+    })
+  })
+
+  it('should not find instance of many regexps using when matcher returns false ', function (done) {
+    var found = []
+    streamGrep(getStream(), /\'((?:\\.|[^\'\\])*)\'/, function () { return false })
+    .on('captured', function(term, line) {
+      found.push(line)
+    })
+    .on('end', function() {
+      found.should.eql([])
       done()
     })
   })


### PR DESCRIPTION
Adds capture groups support.

This will allow you to define more complicated logic based on the result of a fn.

The interface is the same however it can now be used as so:

notice the new captured event.

```
//Captured is called for each capturing group
streamGrep(fs.createReadStream(__filename), [/create/], function (value) {
  if (value) return true
  return false
}).on('captured', function (term, line) {
    console.log('Found', term, 'line', line)
  })
  .on('end', function(found) {
    console.log('Terms found', found)
  })
```
